### PR TITLE
chore: modified prepare script to build the generator

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+# needed to avoid that npm ignores everything from the .gitignore file

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "prepare": "cd packages/generator && npm run build"
+    "prepare": "cd packages/generator && npm install && npm run build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "turbo run test",
-    "lint": "turbo run lint"
+    "lint": "turbo run lint",
+    "prepare": "cd packages/generator && npm build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "prepare": "cd packages/generator && npm install && npm run build"
+    "prepare": "cd packages/generator && npm install && npm run build && chmod +x ./dist/bin.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "prepare": "cd packages/generator && npm build"
+    "prepare": "cd packages/generator && npm run build"
   },
   "keywords": [],
   "author": "",

--- a/packages/generator/.npmignore
+++ b/packages/generator/.npmignore
@@ -1,5 +1,4 @@
 # src
-node_modules
 tsconfig.json
 .eslintrc.json
 # README.md

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -28,7 +28,8 @@
     "lint": "eslint --ext ts,tsx,js,jsx --fix .",
     "test": "vitest",
     "build": "tsc",
-    "format": "prettier --write \"**/*.{ts,tsx,md,json}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md,json}\"",
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@prisma/internals": "^4.11.0",


### PR DESCRIPTION
Modified the prepare script such that the generator is built on `npm install`.
This way, we can develop locally by adding this repo as a dependency and it will build the generator such that we have the necessary distribution files.