### PR TITLE
fix: Modify generator to use new HKT implementation

### DIFF
--- a/packages/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
+++ b/packages/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
@@ -66,7 +66,9 @@ export function writeTableSchemas(dmmf: ExtendedDMMF, fileWriter: CreateFileOpti
     })
     .blankLine();
 
-  writer.writeLine('export const dbSchema = new DbSchema(tableSchemas)');
+  writer
+    .writeLine('export const dbSchema = new DbSchema(tableSchemas)')
+    .writeLine('export type Electric = ElectricClient<typeof dbSchema>');
 }
 
 export function writeFieldNamesArray(

--- a/packages/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
+++ b/packages/generator/src/functions/tableDescriptionWriters/writeTableSchemas.ts
@@ -20,7 +20,7 @@ import { CreateFileOptions, ExtendedDMMF, ExtendedDMMFModel } from '../../classe
  *
  */
 
-export function writeTableDescriptions(dmmf: ExtendedDMMF, fileWriter: CreateFileOptions) {
+export function writeTableSchemas(dmmf: ExtendedDMMF, fileWriter: CreateFileOptions) {
   const writer = fileWriter.writer;
 
   writer.blankLine()
@@ -40,7 +40,7 @@ export function writeTableDescriptions(dmmf: ExtendedDMMF, fileWriter: CreateFil
 
   // Make an object describing all tables
   writer
-    .write(`export const tableDescriptions = `)
+    .write(`export const tableSchemas = `)
     .inlineBlock(() => {
       dmmf.datamodel.models.forEach((model: ExtendedDMMFModel) => {
         const modelName = model.name;
@@ -66,7 +66,7 @@ export function writeTableDescriptions(dmmf: ExtendedDMMF, fileWriter: CreateFil
     })
     .blankLine();
 
-  writer.writeLine('export const dbDescription = new DBDescription(tableDescriptions)');
+  writer.writeLine('export const dbSchema = new DbSchema(tableSchemas)');
 }
 
 export function writeFieldNamesArray(
@@ -145,7 +145,7 @@ export function writeTableDescriptionType(
   }
 
   fileWriter.writer
-    .write('TableDescription<')
+    .write('TableSchema<')
     .newLine()
     .writeLine(`  z.infer<typeof ${modelName}CreateInputSchema>,`)
     .writeLine(`  Prisma.${modelName}CreateArgs['data'],`)

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -27,5 +27,5 @@ export const writeSingleFileImportStatements: WriteStatements = (
     });
   }
 
-  writeImport(`{ TableSchema, DbSchema, Relation, HKT }`, 'electric-sql/client/model');
+  writeImport(`{ TableSchema, DbSchema, Relation, ElectricClient, HKT }`, 'electric-sql/client/model');
 };

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -27,5 +27,5 @@ export const writeSingleFileImportStatements: WriteStatements = (
     });
   }
 
-  writeImport(`{ TableDescription, DBDescription, Relation, HKT }`, 'electric-sql/client/model');
+  writeImport(`{ TableSchema, DbSchema, Relation, HKT }`, 'electric-sql/client/model');
 };

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -27,5 +27,5 @@ export const writeSingleFileImportStatements: WriteStatements = (
     });
   }
 
-  writeImport(`{ TableDescription, DBDescription, Relation }`, 'electric-sql/client/model');
+  writeImport(`{ TableDescription, DBDescription, Relation, HKT }`, 'electric-sql/client/model');
 };

--- a/packages/generator/src/generateSingleFile.ts
+++ b/packages/generator/src/generateSingleFile.ts
@@ -10,7 +10,7 @@ import {
   writeSingleFileArgTypeStatements,
 } from './functions';
 import { CreateOptions } from './types';
-import { writeTableDescriptions } from './functions/tableDescriptionWriters/writeTableDescriptions';
+import { writeTableSchemas } from './functions/tableDescriptionWriters/writeTableSchemas';
 
 export const generateSingleFile = ({ dmmf, path }: CreateOptions) => {
   new FileWriter().createFile(`${path}/index.ts`, (fileWriter) => {
@@ -22,6 +22,6 @@ export const generateSingleFile = ({ dmmf, path }: CreateOptions) => {
     writeSingleFileIncludeSelectStatements(dmmf, fileWriter);
     writeSingleFileInputTypeStatements(dmmf, fileWriter);
     writeSingleFileArgTypeStatements(dmmf, fileWriter);
-    writeTableDescriptions(dmmf, fileWriter);
+    writeTableSchemas(dmmf, fileWriter);
   });
 };


### PR DESCRIPTION
This PR modifies the generator to replace the old fp-ts HKT implementation by the new HKT implementation used by the ts-client ([a53d34f](https://github.com/electric-sql/typescript-client/pull/86/commits/a53d34fecc6df6790738506c14823a23151d4893)). Also modified the generator to use the new names of the ts-client as some types got renamed in [f4fb720](https://github.com/electric-sql/typescript-client/pull/86/commits/f4fb720bda1f04a76d69ec06654313de95dd4728).